### PR TITLE
recalibrate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,7 +87,8 @@
         "format": "cpp",
         "semaphore": "cpp",
         "*.source": "cpp",
-        "source_location": "cpp"
+        "source_location": "cpp",
+        "*.in": "cpp"
     },
     "files.exclude": {
         ".gitignore": true,

--- a/MCB-project/src/drivers.hpp
+++ b/MCB-project/src/drivers.hpp
@@ -28,6 +28,45 @@
 
 namespace src {
     
+class ImuRecalibration {
+public:
+
+void requestRecalibration() {
+    requestingRecalibration = true;
+}
+
+void cancelRequestRecalibration() {
+    requestingRecalibration = false;
+}
+
+bool isRequestingRecalibration() {
+    return requestingRecalibration;
+}
+
+void markAsRecalibrating() {
+    requestingRecalibration = false;
+    isRecalibrating = true;
+}
+
+bool getIsRecalibrating(){
+    return isRecalibrating;
+}
+
+void markAsDoneRecalibrating() {
+    isRecalibrating = false;
+    isDoneRecalibrating = true;
+}
+
+bool getIsDoneRecalibrating() {
+    return isDoneRecalibrating;
+}
+
+private:
+bool requestingRecalibration = false; 
+bool isRecalibrating = false; //occurs in 15 sec countdown
+bool isDoneRecalibrating = false;
+
+}; //class ImuRecalibration
 
 class Drivers : public tap::Drivers {
 public:
@@ -35,9 +74,17 @@ public:
 
     communication::I2CCommunication i2c;
     communication::UARTCommunication uart;
+    ImuRecalibration recal;
     
-public:
+
+
+
+
+
 };  // class Drivers
+
+
+
 
 }  // namespace src
 

--- a/MCB-project/src/drivers.hpp
+++ b/MCB-project/src/drivers.hpp
@@ -100,6 +100,12 @@ bool isAfterSecondCalibration() {
     return state==ImuRecalibrationState::AFTER_SECOND_CALIBRATION;
 }
 
+//when in a best of 3 (or best of 2) game, we allow third and fourth calibrations by going back to first calibration
+void allowAnotherRecalibration() {
+    if(state==ImuRecalibrationState::AFTER_SECOND_CALIBRATION)
+        state = ImuRecalibrationState::AFTER_FIRST_CALIBRATION;
+}
+
 ImuRecalibrationState getState() {
     return state;
 }

--- a/MCB-project/src/main.cpp
+++ b/MCB-project/src/main.cpp
@@ -93,7 +93,10 @@ int main() {
 
         if (refreshTimer.execute()) {
             // tap::buzzer::playNote(&(drivers.pwm), 493);
-            bool goingToRecalibrate = drivers.recal.isRequestingRecalibration() && drivers.refSerial.getRefSerialReceivingData() && drivers.refSerial.getGameData().gameStage == RefSerialData::Rx::GameStage::SETUP  && drivers.refSerial.getGameData().stageTimeRemaining < 20;
+            bool goingToRecalibrate = drivers.recal.isRequestingRecalibration() && 
+                    drivers.refSerial.getRefSerialReceivingData() && 
+                    drivers.refSerial.getGameData().gameStage == RefSerialData::Rx::GameStage::SETUP && 
+                    drivers.refSerial.getGameData().stageTimeRemaining < 10;
             if(goingToRecalibrate){
                 control.stopForImuRecal();
                 drivers.recal.setIsWaiting();

--- a/MCB-project/src/robots/RobotControl.hpp
+++ b/MCB-project/src/robots/RobotControl.hpp
@@ -20,7 +20,8 @@ public:
     //functions that all robots must have or at least share
     virtual void initialize() {}
     virtual void update() {}
-
+    virtual void stopForImuRecal() {} //main calls this to stop the robot to recalibrate the imu
+    virtual void resumeAfterImuRecal() {} //main calls this to after recalibrating the imu
 };
 
 

--- a/MCB-project/src/robots/hero/HeroControl.hpp
+++ b/MCB-project/src/robots/hero/HeroControl.hpp
@@ -98,9 +98,10 @@ public:
 
     void resumeAfterImuRecal() override {
         isStopped = false;
-        update();
-        drivers->commandScheduler.addCommand(&drivetrainFollowKeyboard);
+        gimbal.clearBuildup();
         drivers->commandScheduler.addCommand(&lookMouse);
+        drivers->commandScheduler.addCommand(&drivetrainFollowKeyboard);
+        update();
     }
 
     bool isStopped = true;

--- a/MCB-project/src/robots/hero/HeroControl.hpp
+++ b/MCB-project/src/robots/hero/HeroControl.hpp
@@ -152,8 +152,8 @@ public:
     //keyboard driving
     // Trigger speedModeKey{drivers, Remote::Key::SHIFT}; //drivetrain drive command reads shift
     Trigger stopBeybladeKey{drivers, Remote::Key::X};
-    Trigger beybladeType1Key{drivers, Remote::Key::C};
-    Trigger beybladeType2Key{drivers, Remote::Key::V};
+    Trigger beybladeType1Key{drivers, Remote::Key::C}; //most beyblade, checked in DrivetrainDriveCommand
+    Trigger beybladeType2Key{drivers, Remote::Key::V}; //most translation, checked in DrivetrainDriveCommand
     Trigger startBeybladeKey = beybladeType1Key | beybladeType2Key | scrollUp | scrollDown;
 
     Trigger stopFlywheelTrigger = unjamButton | unjamKey; //doesn't get added to the list of triggers, is special, during a match the only way to turn off flywheels is to turn off the remote

--- a/MCB-project/src/robots/hero/HeroControl.hpp
+++ b/MCB-project/src/robots/hero/HeroControl.hpp
@@ -53,7 +53,7 @@ public:
         unjamButton.whileTrue(&indexerUnjam)->onFalse(&indexerLoad);
         shootButton.whileTrue(&indexerAuto)->onTrue(&shooterStart)->onFalse(&indexerLoad);
         stopFlywheelTrigger.onTrue(&shooterStop);
-        //autoAimKey./*whileTrue(&autoCommand)->*/onFalse(&lookMouse)->whileTrue(&shooterStart);
+        autoAimKey./*whileTrue(&autoCommand)->*/onFalse(&lookMouse)->onTrue(&shooterStart);
         // implement speed mode
 
         toggleUIKey.onTrue(&draw)->onTrue(&drivetrainFollowKeyboard)->onTrue(&lookMouse); //press g to start robot

--- a/MCB-project/src/robots/infantry/InfantryControl.hpp
+++ b/MCB-project/src/robots/infantry/InfantryControl.hpp
@@ -63,6 +63,7 @@ public:
 
         // Mouse and Keyboard mappings
         unjamKey.whileTrue(&indexerUnjam)->onTrue(&openServo);
+        onlyCloseLidKey.onTrue(&closeServo);
         shootKey.whileTrue(&indexerStart)->onTrue(&shooterStart)->onTrue(&closeServo);
         autoAimKey.whileTrue(&autoCommand)->onFalse(&lookMouse)->whileTrue(&shooterStart)->onTrue(&closeServo);
         // implement speed mode
@@ -109,9 +110,10 @@ public:
     
     void resumeAfterImuRecal() override {
         isStopped = false;
-        update();
-        drivers->commandScheduler.addCommand(&drivetrainFollowKeyboard);
+        gimbal.clearBuildup();
         drivers->commandScheduler.addCommand(&lookMouse);
+        drivers->commandScheduler.addCommand(&drivetrainFollowKeyboard);
+        update();
     }
 
     bool isStopped = true;
@@ -168,6 +170,7 @@ public:
     Trigger shootButton{drivers, Remote::Channel::WHEEL, -0.5};
     Trigger unjamButton{drivers, Remote::Channel::WHEEL, 0.5};
     Trigger unjamKey{drivers, Remote::Key::Z}; //or R if based
+    Trigger onlyCloseLidKey{drivers, Remote::Key::CTRL}; //blame peter
     Trigger autoAimKey{drivers, MouseButton::RIGHT};
     Trigger shootKey{drivers, MouseButton::LEFT};
 
@@ -196,7 +199,7 @@ public:
 
     Trigger stopFlywheelTrigger = unjamButton | unjamKey; //doesn't get added to the list of triggers, is special, during a match the only way to turn off flywheels is to turn off the remote
 
-    Trigger* triggers[17] = {&peekLeftButton, &peekRightButton, &joystickDrive0, &joystickDrive1, &joystickDrive2, &shootButton, &unjamButton, &unjamKey, &shootKey, &autoAimKey, &stopBeybladeKey, &beybladeType1Key, &beybladeType2Key, &scrollUp, &scrollDown, &startBeybladeKey, &toggleUIKey};//, &indexSpinButton};
+    Trigger* triggers[18] = {&peekLeftButton, &peekRightButton, &joystickDrive0, &joystickDrive1, &joystickDrive2, &shootButton, &unjamButton, &onlyCloseLidKey, &unjamKey, &shootKey, &autoAimKey, &stopBeybladeKey, &beybladeType1Key, &beybladeType2Key, &scrollUp, &scrollDown, &startBeybladeKey, &toggleUIKey};//, &indexSpinButton};
 
 };
 

--- a/MCB-project/src/robots/infantry/InfantryControl.hpp
+++ b/MCB-project/src/robots/infantry/InfantryControl.hpp
@@ -172,8 +172,8 @@ public:
     //keyboard driving
     // Trigger speedModeKey{drivers, Remote::Key::SHIFT}; //drivetrain drive command reads shift
     Trigger stopBeybladeKey{drivers, Remote::Key::X};
-    Trigger beybladeType1Key{drivers, Remote::Key::C};
-    Trigger beybladeType2Key{drivers, Remote::Key::V};
+    Trigger beybladeType1Key{drivers, Remote::Key::C}; //most beyblade, checked in DrivetrainDriveCommand
+    Trigger beybladeType2Key{drivers, Remote::Key::V}; //most translation, checked in DrivetrainDriveCommand
     Trigger startBeybladeKey = beybladeType1Key | beybladeType2Key | scrollUp | scrollDown;
 
     Trigger stopFlywheelTrigger = unjamButton | unjamKey; //doesn't get added to the list of triggers, is special, during a match the only way to turn off flywheels is to turn off the remote

--- a/MCB-project/src/robots/infantry/InfantryControl.hpp
+++ b/MCB-project/src/robots/infantry/InfantryControl.hpp
@@ -65,7 +65,7 @@ public:
         unjamKey.whileTrue(&indexerUnjam)->onTrue(&openServo);
         onlyCloseLidKey.onTrue(&closeServo);
         shootKey.whileTrue(&indexerStart)->onTrue(&shooterStart)->onTrue(&closeServo);
-        autoAimKey.whileTrue(&autoCommand)->onFalse(&lookMouse)->whileTrue(&shooterStart)->onTrue(&closeServo);
+        autoAimKey.whileTrue(&autoCommand)->onFalse(&lookMouse)->onTrue(&shooterStart)->onTrue(&closeServo);
         // implement speed mode
 
         toggleUIKey.onTrue(&draw)->onTrue(&drivetrainFollowKeyboard)->onTrue(&lookMouse); //press g to start robot

--- a/MCB-project/src/robots/infantry/InfantryControl.hpp
+++ b/MCB-project/src/robots/infantry/InfantryControl.hpp
@@ -82,11 +82,12 @@ public:
         joystickDrive1.onTrue(&drivetrainFollowJoystick)->onTrue(&lookJoystick);
         joystickDrive2.onTrue(&beybladeJoystick)->onTrue(&lookJoystick);
 
-    // drivers->terminalSerial.initialize();
-
+        isStopped = false;
     }
 
     void update() override {
+        if(isStopped)
+            return;
 
         for (Trigger* trigger : triggers) {
             trigger->update();
@@ -97,6 +98,23 @@ public:
             stopFlywheelTrigger.update();
         }
     }
+
+    void stopForImuRecal() override {
+        drivers->commandScheduler.addCommand(&stopGimbal);
+        drivers->commandScheduler.addCommand(&shooterStop);
+        drivers->commandScheduler.addCommand(&stopDriveCommand);
+        drivers->commandScheduler.addCommand(&indexerStop);
+        isStopped = true;
+    }
+    
+    void resumeAfterImuRecal() override {
+        isStopped = false;
+        update();
+        drivers->commandScheduler.addCommand(&drivetrainFollowKeyboard);
+        drivers->commandScheduler.addCommand(&lookMouse);
+    }
+
+    bool isStopped = true;
 
     src::Drivers *drivers;
     InfantryHardware hardware;

--- a/MCB-project/src/robots/infantry/InfantryControl.hpp
+++ b/MCB-project/src/robots/infantry/InfantryControl.hpp
@@ -57,11 +57,12 @@ public:
         indexer.setDefaultCommand(&indexerStop);
 
         shootButton.onTrue(&shooterStart)->whileTrue(&indexerStart)->onTrue(&closeServo);
-        unjamButton.onTrue(&shooterStop)->whileTrue(&indexerUnjam)->onTrue(&openServo);
+        unjamButton.whileTrue(&indexerUnjam)->onTrue(&openServo);
 
+        stopFlywheelTrigger.onTrue(&shooterStop);
 
         // Mouse and Keyboard mappings
-        unjamKey.whileTrue(&indexerUnjam)->onTrue(&shooterStop)->onTrue(&openServo);
+        unjamKey.whileTrue(&indexerUnjam)->onTrue(&openServo);
         shootKey.whileTrue(&indexerStart)->onTrue(&shooterStart)->onTrue(&closeServo);
         autoAimKey.whileTrue(&autoCommand)->onFalse(&lookMouse)->whileTrue(&shooterStart)->onTrue(&closeServo);
         // implement speed mode
@@ -89,6 +90,11 @@ public:
 
         for (Trigger* trigger : triggers) {
             trigger->update();
+        }
+
+        //if we don't have ref uart or we do and we aren't currently in game, we are able to stop flywheels by buttons
+        if(!drivers->refSerial.getRefSerialReceivingData() || drivers->refSerial.getGameData().gameStage!=RefSerialData::Rx::GameStage::IN_GAME){
+            stopFlywheelTrigger.update();
         }
     }
 
@@ -169,6 +175,8 @@ public:
     Trigger beybladeType1Key{drivers, Remote::Key::C};
     Trigger beybladeType2Key{drivers, Remote::Key::V};
     Trigger startBeybladeKey = beybladeType1Key | beybladeType2Key | scrollUp | scrollDown;
+
+    Trigger stopFlywheelTrigger = unjamButton | unjamKey; //doesn't get added to the list of triggers, is special, during a match the only way to turn off flywheels is to turn off the remote
 
     Trigger* triggers[17] = {&peekLeftButton, &peekRightButton, &joystickDrive0, &joystickDrive1, &joystickDrive2, &shootButton, &unjamButton, &unjamKey, &shootKey, &autoAimKey, &stopBeybladeKey, &beybladeType1Key, &beybladeType2Key, &scrollUp, &scrollDown, &startBeybladeKey, &toggleUIKey};//, &indexSpinButton};
 

--- a/MCB-project/src/robots/sentry/SentryControl.hpp
+++ b/MCB-project/src/robots/sentry/SentryControl.hpp
@@ -57,9 +57,14 @@ public:
         joystickDrive0.onTrue(&lookJoystick);
         joystickDrive1.onTrue(&drivetrainFollowJoystick)->onTrue(&lookJoystick)->onTrue(&odoPointForwards);
         joystickDrive2.onTrue(&beybladeJoystick)->onTrue(&lookJoystick)->onTrue(&odoPointForwards);
+        
+        isStopped = false;
     }
 
     void update() override {
+        if(isStopped)
+            return;
+
         for (Trigger* trigger : triggers) {
             trigger->update();
         }
@@ -69,6 +74,21 @@ public:
             stopFlywheelTrigger.update();
         }
     }
+
+    void stopForImuRecal() override {
+        drivers->commandScheduler.addCommand(&stopGimbal);
+        drivers->commandScheduler.addCommand(&shooterStop);
+        drivers->commandScheduler.addCommand(&stopDriveCommand);
+        drivers->commandScheduler.addCommand(&indexerStop);
+        isStopped = true;
+    }
+
+    void resumeAfterImuRecal() override {
+        isStopped = false;
+        update();
+    }
+
+    bool isStopped = true;
 
     src::Drivers* drivers;
     SentryHardware hardware;

--- a/MCB-project/src/robots/sentry/SentryControl.hpp
+++ b/MCB-project/src/robots/sentry/SentryControl.hpp
@@ -85,6 +85,7 @@ public:
 
     void resumeAfterImuRecal() override {
         isStopped = false;
+        gimbal.clearBuildup();
         update();
     }
 

--- a/MCB-project/src/robots/sentry/SentryControl.hpp
+++ b/MCB-project/src/robots/sentry/SentryControl.hpp
@@ -45,10 +45,12 @@ public:
         indexer.setDefaultCommand(&indexerStop);
         odo.setDefaultCommand(&odoStop);
 
+        
         shootButton.onTrue(&shooterStart)->whileTrue(&indexerStart);
-        unjamButton.onTrue(&shooterStop)->whileTrue(&indexerUnjam);
+        unjamButton.whileTrue(&indexerUnjam);
+        stopFlywheelTrigger.onTrue(&shooterStop);
 
-        autoFireTrigger.whileTrue(&autoFire)->onFalse(&lookJoystick)->onFalse(&shooterStop);
+        autoFireTrigger.whileTrue(&autoFire)->onFalse(&lookJoystick);
         autoDriveTrigger.whileTrue(&autoDrive)->onTrue(&odoPointForwards);
         // drive commands 
 
@@ -60,6 +62,11 @@ public:
     void update() override {
         for (Trigger* trigger : triggers) {
             trigger->update();
+        }
+        
+        //if we don't have ref uart or we do and we aren't currently in game, we are able to stop flywheels by buttons
+        if(!drivers->refSerial.getRefSerialReceivingData() || drivers->refSerial.getGameData().gameStage!=RefSerialData::Rx::GameStage::IN_GAME){
+            stopFlywheelTrigger.update();
         }
     }
 
@@ -115,6 +122,7 @@ public:
     Trigger autoFireTrigger{drivers, Remote::Switch::LEFT_SWITCH, Remote::SwitchState::UP};
     Trigger autoDriveTrigger{drivers, Remote::Switch::RIGHT_SWITCH, Remote::SwitchState::UP};
 
+    Trigger stopFlywheelTrigger = unjamButton | !autoFireTrigger; //doesn't get added to the list of triggers, is special, during a match the only way to turn off flywheels is to turn off the remote
 
     Trigger* triggers[7] = {&joystickDrive0, &joystickDrive1, &joystickDrive2, &shootButton, &unjamButton, &autoFireTrigger, &autoDriveTrigger};  //, &indexSpinButton};
 };

--- a/MCB-project/src/subsystems/drivetrain/DrivetrainDriveCommand.cpp
+++ b/MCB-project/src/subsystems/drivetrain/DrivetrainDriveCommand.cpp
@@ -29,6 +29,12 @@ void DrivetrainDriveCommand::execute() {
             drivetrain->linearVelocityMultiplierTimes100 += scroll * LINEAR_VELOCITY_INCREMENT_TIMES_100;
         oldScroll = scroll;
 
+        if(drivers->remote.keyPressed(Remote::Key::V))
+            drivetrain->linearVelocityMultiplierTimes100 = MAX_LINEAR_VELOCITY_TIMES_100;
+            
+        if(drivers->remote.keyPressed(Remote::Key::C))
+            drivetrain->linearVelocityMultiplierTimes100 = MIN_LINEAR_VELOCITY_TIMES_100;
+
         //clamp
         if(drivetrain->linearVelocityMultiplierTimes100>MAX_LINEAR_VELOCITY_TIMES_100) 
             drivetrain->linearVelocityMultiplierTimes100 = MAX_LINEAR_VELOCITY_TIMES_100;

--- a/MCB-project/src/subsystems/drivetrain/DrivetrainSubsystem.hpp
+++ b/MCB-project/src/subsystems/drivetrain/DrivetrainSubsystem.hpp
@@ -70,8 +70,7 @@ public:  // Public Methods
 
     void setTargetPosition(Vector2d targetPosition, Pose2d currentPosition, Pose2d inputVelocity);
     /*
-     * Call this function to set all DriveTrain motors to 0 desired RPM. CALL setMotorSpeeds() FOR
-     * THIS TO WORK
+     * Call this function to set all DriveTrain motors to 0 desired RPM.
      */
     void stopMotors();
 

--- a/MCB-project/src/subsystems/gimbal/GimbalSubsystem.cpp
+++ b/MCB-project/src/subsystems/gimbal/GimbalSubsystem.cpp
@@ -49,13 +49,13 @@ void GimbalSubsystem::updateMotors(float changeInTargetYaw, float targetPitch) {
     pitchVel += gimbalPitchAngularVelocity;
 #endif
 
-    targetPitch = std::clamp(targetPitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
+    prevTargetPitch = std::clamp(targetPitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
 
     driveTrainEncoder = getYawEncoderValue();
     yawEncoderCache = driveTrainEncoder;
     // THIS LINE BELOW WAS CAUSING ERROR
     targetYawAngleWorld += changeInTargetYaw;  // std::fmod(targetYawAngleWorld + changeInTargetYaw, 2 * PI);
-    pitchMotorVoltage = getPitchVoltage(targetPitch, pitch, pitchVel, dt);
+    pitchMotorVoltage = getPitchVoltage(prevTargetPitch, pitch, pitchVel, dt);
 
     yawMotorVoltage = getYawVoltage(driveTrainAngularVelocity, yawAngleRelativeWorld, yawAngularVelocity, targetYawAngleWorld, changeInTargetYaw / dt, dt);
     // moved
@@ -65,13 +65,13 @@ void GimbalSubsystem::updateMotors(float changeInTargetYaw, float targetPitch) {
 void GimbalSubsystem::updateMotorsAndVelocity(float changeInTargetYaw, float targetPitch, float targetYawVel, float targetPitchVel) {
     float pitch = getPitchEncoderValue();
 
-    targetPitch = std::clamp(targetPitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
+    prevTargetPitch = std::clamp(targetPitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
 
     driveTrainEncoder = getYawEncoderValue();
     yawEncoderCache = driveTrainEncoder;
     // THIS LINE BELOW WAS CAUSING ERROR
     targetYawAngleWorld += changeInTargetYaw;  // std::fmod(targetYawAngleWorld + changeInTargetYaw, 2 * PI);
-    pitchMotorVoltage = getPitchVoltage(targetPitch, pitch, targetPitchVel, dt);
+    pitchMotorVoltage = getPitchVoltage(prevTargetPitch, pitch, targetPitchVel, dt);
 
     yawMotorVoltage = getYawVoltage(driveTrainAngularVelocity, yawAngleRelativeWorld, yawAngularVelocity, targetYawAngleWorld, targetYawVel, dt);
 }

--- a/MCB-project/src/subsystems/gimbal/GimbalSubsystem.cpp
+++ b/MCB-project/src/subsystems/gimbal/GimbalSubsystem.cpp
@@ -88,10 +88,14 @@ void GimbalSubsystem::stopMotors() {
     // #endif
     targetYawAngleWorld = yawAngleRelativeWorld;
 
+    clearBuildup();
+}
+
+void GimbalSubsystem::clearBuildup() {
     pitchController.clearBuildup();
     yawController.clearBuildup();
 }
-
+    
 void GimbalSubsystem::reZeroYaw() {
     // TODO
 }

--- a/MCB-project/src/subsystems/gimbal/GimbalSubsystem.cpp
+++ b/MCB-project/src/subsystems/gimbal/GimbalSubsystem.cpp
@@ -44,21 +44,27 @@ void GimbalSubsystem::refresh() {
 void GimbalSubsystem::updateMotors(float changeInTargetYaw, float targetPitch) {
     float pitchVel = getPitchVel();
     float pitch = getPitchEncoderValue();
+    prevTargetPitch = std::clamp(targetPitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
+    
 #if defined(INFANTRY) or defined(HERO) // chicken mode, gets bad when imu drifts
     targetPitch -= gimbalPitchAngleRelativeWorld;
     pitchVel += gimbalPitchAngularVelocity;
 #endif
 
-    prevTargetPitch = std::clamp(targetPitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
+    targetPitch = std::clamp(targetPitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
 
     driveTrainEncoder = getYawEncoderValue();
     yawEncoderCache = driveTrainEncoder;
     // THIS LINE BELOW WAS CAUSING ERROR
     targetYawAngleWorld += changeInTargetYaw;  // std::fmod(targetYawAngleWorld + changeInTargetYaw, 2 * PI);
-    pitchMotorVoltage = getPitchVoltage(prevTargetPitch, pitch, pitchVel, dt);
+    pitchMotorVoltage = getPitchVoltage(targetPitch, pitch, pitchVel, dt);
 
     yawMotorVoltage = getYawVoltage(driveTrainAngularVelocity, yawAngleRelativeWorld, yawAngularVelocity, targetYawAngleWorld, changeInTargetYaw / dt, dt);
     // moved
+}
+
+float GimbalSubsystem::getPrevTargetPitch() {
+    return prevTargetPitch;
 }
 
 // alternate version of update motors to use with CV

--- a/MCB-project/src/subsystems/gimbal/GimbalSubsystem.hpp
+++ b/MCB-project/src/subsystems/gimbal/GimbalSubsystem.hpp
@@ -100,6 +100,8 @@ public:  // Public Methods
 
     float getYawAngleRelativeWorld();
 
+    void clearBuildup();
+
 private:  // Private Methods
     int getPitchVoltage(float targetAngle, float pitchAngleRelativeGimbal, float pitchAngularVelocity, float dt);
     int getYawVoltage(float driveTrainAngularVelocity, float yawAngleRelativeWorld, float yawAngularVelocity, float desiredAngleWorld, float inputVel, float dt);

--- a/MCB-project/src/subsystems/gimbal/GimbalSubsystem.hpp
+++ b/MCB-project/src/subsystems/gimbal/GimbalSubsystem.hpp
@@ -47,6 +47,8 @@ private:  // Private Variables
     std::uniform_int_distribution<int> distYaw;
     std::uniform_int_distribution<int> distPitch;
 
+    float prevTargetPitch = 0;
+
 public:  // Public Methods
     GimbalSubsystem(src::Drivers* drivers, tap::motor::DjiMotor* yaw, tap::motor::DjiMotor* pitch);
 
@@ -70,6 +72,8 @@ public:  // Public Methods
      * tells the motors to move the gimbal to its specified angle calculated in update();
      */
     void updateMotors(float changeInTargetYaw, float targetPitch);
+
+    float getPrevTargetPitch();
 
     /*
      *   Straight up gives a full state for the controllers to target

--- a/MCB-project/src/subsystems/gimbal/GimbalSubsystemConstants.hpp
+++ b/MCB-project/src/subsystems/gimbal/GimbalSubsystemConstants.hpp
@@ -22,7 +22,7 @@ static constexpr float MAX_PITCH_DOWN = PI_CONST / 180 * 30;
 
 static constexpr float YAW_OFFSET =  0.75 * PI_CONST ;
 
-static constexpr float PITCH_OFFSET = 0.3185;  // to make gimbal horizontal when told to go to 0
+static constexpr float PITCH_OFFSET = (.12 ) * PI_CONST;  // to make gimbal horizontal when told to go to 0
 
 static constexpr float YAW_TOTAL_RATIO = 32319.0f / 748.0f;  // unitless, ratio of encoder counts to degrees of rotation
 

--- a/MCB-project/src/subsystems/gimbal/MouseMoveCommand.cpp
+++ b/MCB-project/src/subsystems/gimbal/MouseMoveCommand.cpp
@@ -4,20 +4,16 @@
 namespace commands {
 
 void MouseMoveCommand::initialize() {
-    pitch = gimbal->getPitchEncoderValue();
 }
+
 void MouseMoveCommand::execute() {
-    yaw = MOUSE_YAW_PROPORTIONAL * (drivers->remote.getMouseX());
-    pitch += MOUSE_PITCH_PROPORTIONAL * (drivers->remote.getMouseY());
+    float yawInc = MOUSE_YAW_PROPORTIONAL * (drivers->remote.getMouseX());
+    float pitchInc = MOUSE_PITCH_PROPORTIONAL * (drivers->remote.getMouseY());
 
-    yawvel = gimbal->getYawVel();
-    pitchvel = gimbal->getPitchVel(); 
-
-    pitch = std::clamp(pitch, -MAX_PITCH_DOWN, MAX_PITCH_UP);
-    gimbal->updateMotors(yaw, pitch);
+    gimbal->updateMotors(yawInc, gimbal->getPrevTargetPitch() + pitchInc);
 }
 
-void MouseMoveCommand::end(bool) { pitch = 0; }
+void MouseMoveCommand::end(bool) {}
 
 bool MouseMoveCommand::isFinished() const { return !drivers->remote.isConnected(); }
 }  // namespace commands

--- a/MCB-project/src/subsystems/gimbal/MouseMoveCommand.hpp
+++ b/MCB-project/src/subsystems/gimbal/MouseMoveCommand.hpp
@@ -40,8 +40,6 @@ private:
 protected:
     src::Drivers* drivers;
     GimbalSubsystem* gimbal;
-    float yaw = 0.0f, pitch = 0.0f;
-    float yawvel = 0.0f, pitchvel = 0.0f;
 
 };
 }  // namespace commands

--- a/MCB-project/src/subsystems/jetson/AutoAimCommand.hpp
+++ b/MCB-project/src/subsystems/jetson/AutoAimCommand.hpp
@@ -47,5 +47,7 @@ private:
     bool isCalibrated = false;
 
     uint32_t lastSeenTime = 0;
+    float pitch = 0.0f;
+    float yawvel = 0.0f, pitchvel = 0.0f;
 };
 }  // namespace commands

--- a/MCB-project/src/subsystems/ui/Countdown.hpp
+++ b/MCB-project/src/subsystems/ui/Countdown.hpp
@@ -12,7 +12,7 @@ using namespace subsystems;
 //this is drawn to the side so you can still know the countdown
 class Countdown : public GraphicsContainer {
 public:
-    Countdown(tap::Drivers* drivers) : drivers(drivers) {
+    Countdown(src::Drivers* drivers) : drivers(drivers) {
         addGraphicsObject(&number);
         number.x = X_POSITION;
         number.y = Y_POSITION;
@@ -20,6 +20,10 @@ public:
     }
 
     void update() {
+        
+        // if(drivers->remote.keyPressed(Remote::Key::R))
+        //     drivers->recal.requestRecalibration();
+
         if (drivers->refSerial.getRefSerialReceivingData()) {
             RefSerialData::Rx::GameData gameData = drivers->refSerial.getGameData();
             number.integer = gameData.stageTimeRemaining;
@@ -39,7 +43,7 @@ public:
     }
 
 private:
-    tap::Drivers* drivers;
+    src::Drivers* drivers;
 
     static constexpr uint16_t X_POSITION = 1680; //pixels, all numbers at the same y level on screen
     static constexpr uint16_t Y_POSITION = 610; //pixels, all numbers at the same y level on screen

--- a/MCB-project/src/subsystems/ui/HeroDrawCommand.hpp
+++ b/MCB-project/src/subsystems/ui/HeroDrawCommand.hpp
@@ -18,6 +18,7 @@
 #include "AllRobotHealthNumbers.hpp"
 #include "Countdown.hpp"
 #include "LinearVelocityIndicator.hpp"
+#include "ImuRecalibrationIndicator.hpp"
 #include "drivers.hpp"
 
 namespace commands {
@@ -25,7 +26,7 @@ using subsystems::UISubsystem;
 
 class HeroDrawCommand : public tap::control::Command, GraphicsContainer {
 public:
-    HeroDrawCommand(tap::Drivers* drivers, UISubsystem* ui, GimbalSubsystem* gimbal, FlywheelSubsystem* flywheel, HeroIndexerSubsystem* indexer, DrivetrainSubsystem* drivetrain)
+    HeroDrawCommand(src::Drivers* drivers, UISubsystem* ui, GimbalSubsystem* gimbal, FlywheelSubsystem* flywheel, HeroIndexerSubsystem* indexer, DrivetrainSubsystem* drivetrain)
         : drivers(drivers),
           ui(ui),
           gimbal(gimbal),
@@ -43,6 +44,7 @@ public:
         addGraphicsObject(&numbers);
         addGraphicsObject(&countdown);
         addGraphicsObject(&velo);
+        addGraphicsObject(&recal);
     };
 
     void initialize() override { ui->setTopLevelContainer(this); };
@@ -57,6 +59,7 @@ public:
         numbers.update();
         countdown.update();
         velo.update();
+        recal.update();
     };
 
     //ui subsystem won't do anything until its top level container is set, so we are ok to add objects to the command in the constructor
@@ -67,7 +70,7 @@ public:
     const char* getName() const override { return "hero ui draw command"; }
 
 private:
-    tap::Drivers* drivers;
+    src::Drivers* drivers;
     UISubsystem* ui; 
     GimbalSubsystem* gimbal;
     FlywheelSubsystem* flywheel;
@@ -84,5 +87,6 @@ private:
     AllRobotHealthNumbers numbers{drivers};
     Countdown countdown{drivers};
     LinearVelocityIndicator velo{drivetrain};
+    ImuRecalibrationIndicator recal{drivers};
 };
 }  // namespace commands

--- a/MCB-project/src/subsystems/ui/HitRing.hpp
+++ b/MCB-project/src/subsystems/ui/HitRing.hpp
@@ -26,6 +26,7 @@ public:
             expirationTimeouts[i].stop();        // timers might be initialized started, we need them to be stopped until we get hit
             this->addGraphicsObject(rings + i);  // pointer math
             rings[i].hide();
+            rings[i].thickness = THICKNESS;
         }
     }
 
@@ -39,8 +40,8 @@ public:
         for (int i = 0; i < NUM_HISTORY; i++) {
             if (expirationTimeouts[i].isStopped()) continue;  // if timer not running, ignore this ring and go to the next
 
-            // downgrade pink to purple
-            if (expirationTimeouts[i].timeRemaining() > RECENT_TIME) {
+            // downgrade white to purple
+            if (expirationTimeouts[i].timeRemaining() - EXPIRATION_TIME > RECENT_TIME) {
                 rings[i].color = UISubsystem::Color::PURPLISH_RED;
             }
 
@@ -73,7 +74,7 @@ public:
                 hitOrientations[nextIndex] = -encoder + imu + 90 * ((uint16_t) robotData.damagedArmorId);
                 rings[nextIndex].show();
                 expirationTimeouts[nextIndex].restart(RECENT_TIME + EXPIRATION_TIME);
-                rings[nextIndex].color = UISubsystem::Color::PINK;
+                rings[nextIndex].color = UISubsystem::Color::WHITE;
                 updateRing(nextIndex, imu);
 
                 //get the next index
@@ -91,13 +92,13 @@ private:
 
     uint16_t previousHp;
 
-    static constexpr uint16_t THICKNESS = 2;        // pixels
-    static constexpr uint16_t ARC_LEN = 6;          // degrees
-    static constexpr uint16_t STARTING_SIZE = 190;  // pixels
-    static constexpr uint16_t SIZE_INCREMENT = 5;   // pixels. If 0, the history of lines will all be overlapping,
+    static constexpr uint16_t THICKNESS = 10;        // pixels
+    static constexpr uint16_t ARC_LEN = 10;          // degrees
+    static constexpr uint16_t STARTING_SIZE = 180;  // pixels
+    static constexpr uint16_t SIZE_INCREMENT = 15;   // pixels. If 0, the history of lines will all be overlapping
 
-    static constexpr int NUM_HISTORY = 5;              // how many shots to keep track of
-    static constexpr uint32_t RECENT_TIME = 200;       // once hit, it shows for 0.2 seconds pink
+    static constexpr int NUM_HISTORY = 3;              // how many shots to keep track of
+    static constexpr uint32_t RECENT_TIME = 500;       // once hit, it shows for 0.5 seconds white
     static constexpr uint32_t EXPIRATION_TIME = 5000;  // then next it shows for 5 seconds purple
 
     Arc rings[NUM_HISTORY];

--- a/MCB-project/src/subsystems/ui/ImuRecalibrationIndicator.hpp
+++ b/MCB-project/src/subsystems/ui/ImuRecalibrationIndicator.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "subsystems/ui/UISubsystem.hpp"
+#include "util/ui/GraphicsContainer.hpp"
+#include "util/ui/SimpleGraphicsObjects.hpp"
+
+using namespace subsystems;
+
+//press ctrl r to schedule a imu recalibration just before the match starts
+//press r to unschedule it
+class ImuRecalibrationIndicator : public GraphicsContainer {
+public:
+    ImuRecalibrationIndicator(src::Drivers* drivers) : drivers(drivers) {
+        addGraphicsObject(&line1);
+        addGraphicsObject(&line2);
+    }
+
+    void update() {
+        if (drivers->refSerial.getRefSerialReceivingData() && drivers->refSerial.getGameData().gameStage>RefSerialData::Rx::GameStage::COUNTDOWN){
+            line1.hide();
+            line2.hide();
+            return;
+        }
+
+        if(expectingRecalibration && drivers->recal.getIsDoneRecalibrating()){
+            line1.setString("Done Recalibrating");
+            line2.setString("");
+            line1.color = colorDoneRecalibrating;
+            line2.color = colorDoneRecalibrating;
+        } else if(drivers->recal.getIsRecalibrating()){
+            line1.setString("Recalibrating");
+            line2.setString("");
+            line1.color = colorRecalibrating;
+            line2.color = colorRecalibrating;
+            expectingRecalibration = true;
+        } else if (drivers->recal.isRequestingRecalibration()) {
+            line1.setString("Imu recal scheduled");
+            line2.setString("R to cancel");
+            line1.color = colorScheduled;
+            line2.color = colorScheduled;
+            
+            if(!ignoreKeyPresses && drivers->remote.keyPressed(Remote::Key::R)){
+                drivers->recal.cancelRequestRecalibration();
+                ignoreKeyPresses = true;
+                update();
+            }
+        } else {
+            line1.setString("CTRL+R to schedule");
+            line2.setString("imu recalibration");
+            line1.color = colorUnscheduled;
+            line2.color = colorUnscheduled;
+
+            if(!ignoreKeyPresses && drivers->remote.keyPressed(Remote::Key::CTRL) && drivers->remote.keyPressed(Remote::Key::R)){
+                drivers->recal.requestRecalibration();
+                ignoreKeyPresses = true;
+                update();
+            }
+
+            expectingRecalibration = false;
+        }
+
+        if(!drivers->remote.keyPressed(Remote::Key::R))
+            ignoreKeyPresses = false;
+    }
+
+private:
+    src::Drivers* drivers;
+
+    static constexpr uint16_t X_POSITION = 1680; //pixels, all numbers at the same y level on screen
+    static constexpr uint16_t Y_POSITION = 610; //pixels, all numbers at the same y level on screen
+    static constexpr uint16_t LINE_HEIGHT = 200; //pixels, this is a large number
+    static constexpr uint16_t THICKENSS = 10; //pixels, this is a large number
+
+    
+    static constexpr UISubsystem::Color colorUnscheduled = UISubsystem::Color::CYAN;
+    static constexpr UISubsystem::Color colorScheduled = UISubsystem::Color::ORANGE;
+    static constexpr UISubsystem::Color colorRecalibrating = UISubsystem::Color::PURPLISH_RED;
+    static constexpr UISubsystem::Color colorDoneRecalibrating = UISubsystem::Color::GREEN;
+
+    StringGraphic line1{UISubsystem::Color::CYAN, "l1", 80, 600, 20, 2};
+    StringGraphic line2{UISubsystem::Color::CYAN, "l2", 80, 550, 20, 2};
+
+    bool ignoreKeyPresses = false;
+    bool expectingRecalibration = false;
+};

--- a/MCB-project/src/subsystems/ui/InfantryDrawCommand.hpp
+++ b/MCB-project/src/subsystems/ui/InfantryDrawCommand.hpp
@@ -21,6 +21,7 @@
 #include "AllRobotHealthNumbers.hpp"
 #include "Countdown.hpp"
 #include "LinearVelocityIndicator.hpp"
+#include "ImuRecalibrationIndicator.hpp"
 #include "drivers.hpp"
 
 namespace commands {
@@ -28,7 +29,7 @@ using subsystems::UISubsystem;
 
 class InfantryDrawCommand : public tap::control::Command, GraphicsContainer {
 public:
-    InfantryDrawCommand(tap::Drivers* drivers, UISubsystem* ui, GimbalSubsystem* gimbal, FlywheelSubsystem* flywheel, IndexerSubsystem* indexer, DrivetrainSubsystem* drivetrain, ServoSubsystem* servo)
+    InfantryDrawCommand(src::Drivers* drivers, UISubsystem* ui, GimbalSubsystem* gimbal, FlywheelSubsystem* flywheel, IndexerSubsystem* indexer, DrivetrainSubsystem* drivetrain, ServoSubsystem* servo)
         : drivers(drivers),
           ui(ui),
           gimbal(gimbal),
@@ -49,6 +50,7 @@ public:
         addGraphicsObject(&numbers);
         addGraphicsObject(&countdown);
         addGraphicsObject(&velo);
+        addGraphicsObject(&recal);
     };
 
     void initialize() override { ui->setTopLevelContainer(this); };
@@ -65,6 +67,7 @@ public:
         numbers.update();
         countdown.update();
         velo.update();
+        recal.update();
     };
 
     //ui subsystem won't do anything until its top level container is set, so we are ok to add objects to the command in the constructor
@@ -75,7 +78,7 @@ public:
     const char* getName() const override { return "infantry ui draw command"; }
 
 private:
-    tap::Drivers* drivers;
+    src::Drivers* drivers;
     UISubsystem* ui; 
     GimbalSubsystem* gimbal;
     FlywheelSubsystem* flywheel;
@@ -95,5 +98,6 @@ private:
     AllRobotHealthNumbers numbers{drivers};
     Countdown countdown{drivers};
     LinearVelocityIndicator velo{drivetrain};
+    ImuRecalibrationIndicator recal{drivers};
 };
 }  // namespace commands

--- a/MCB-project/src/subsystems/ui/UISubsystem.cpp
+++ b/MCB-project/src/subsystems/ui/UISubsystem.cpp
@@ -48,18 +48,19 @@ bool UISubsystem::run() {
 
     PT_WAIT_UNTIL(drivers->refSerial.getRefSerialReceivingData());
     
-    // delete the things
-    PT_CALL(refSerialTransmitter.deleteGraphicLayer(RefSerialTransmitter::Tx::DELETE_ALL, 0));
+    // delete on all layers. we currently only use layer 0, but other teams could have put stuff on other layers we need to delete
+    for(graphicsIndex=0; graphicsIndex<10; graphicsIndex++){
+        PT_CALL(refSerialTransmitter.deleteGraphicLayer(RefSerialTransmitter::Tx::DELETE_ALL, graphicsIndex));
+        
+        //need to wait for graphics to delete. This might wait longer than is required, but it allows things to draw.
+        delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&messageCharacter));
+        PT_WAIT_UNTIL(delayTimeout.execute());
+    } 
+
     if (topLevelContainer){
         topLevelContainer->hasBeenCleared();
         topLevelContainer->resetIteration();
-    } 
-
-    
-    //need to wait for graphics to delete. This might wait longer than is required, but it allows things to draw.
-    delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&messageCharacter));
-    PT_WAIT_UNTIL(delayTimeout.execute());
-
+    }
 
     graphicsIndex=0; //might start with one or two already in the array from last time, so set it once outside of the loop
     while (topLevelContainer && !needToRestart) {

--- a/MCB-project/src/subsystems/ui/UISubsystem.cpp
+++ b/MCB-project/src/subsystems/ui/UISubsystem.cpp
@@ -5,7 +5,10 @@ namespace subsystems {
 // define the static variable, if this isnt here things go wrong saying it is a undefined reference
 uint32_t UISubsystem::currGraphicName = 0;
 
-UISubsystem::UISubsystem(tap::Drivers* drivers) : tap::control::Subsystem(drivers), drivers(drivers), refSerialTransmitter(drivers) { }
+UISubsystem::UISubsystem(tap::Drivers* drivers) : tap::control::Subsystem(drivers), drivers(drivers), refSerialTransmitter(drivers) { 
+    for(int i=0; i<NUM_LAYERS; i++)
+        layersAreCleared[i] = false;
+}
 
 uint32_t UISubsystem::getUnusedGraphicName() {
     if (currGraphicName > 0xffffff) {
@@ -49,12 +52,16 @@ bool UISubsystem::run() {
     PT_WAIT_UNTIL(drivers->refSerial.getRefSerialReceivingData());
     
     // delete on all layers. we currently only use layer 0, but other teams could have put stuff on other layers we need to delete
-    for(graphicsIndex=0; graphicsIndex<10; graphicsIndex++){
+    for(graphicsIndex=0; graphicsIndex<NUM_LAYERS; graphicsIndex++){
+        if(layersAreCleared[graphicsIndex])
+            continue;
+
         PT_CALL(refSerialTransmitter.deleteGraphicLayer(RefSerialTransmitter::Tx::DELETE_ALL, graphicsIndex));
         
         //need to wait for graphics to delete. This might wait longer than is required, but it allows things to draw.
         delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&messageCharacter));
         PT_WAIT_UNTIL(delayTimeout.execute());
+        layersAreCleared[graphicsIndex] = true;
     } 
 
     if (topLevelContainer){
@@ -79,6 +86,7 @@ bool UISubsystem::run() {
             if (nextGraphicsObject->isStringGraphic()) {
                 // if it is a string, keep the array as it is and send the string on its own
                 nextGraphicsObject->configCharacterData(&messageCharacter);
+                layersAreCleared[messageCharacter.graphicData.layer] = false;
                 PT_CALL(refSerialTransmitter.sendGraphic(&messageCharacter));
                 delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&messageCharacter));
                 PT_WAIT_UNTIL(delayTimeout.execute());
@@ -110,21 +118,28 @@ bool UISubsystem::run() {
         // so we have up to 7 objects to update. Would do a switch case but might confict with protothread's switch case
         if (numToSend == 1) {
             objectsToSend[0]->configGraphicData(&message1.graphicData);
+            layersAreCleared[message1.graphicData.layer] = false;
             PT_CALL(refSerialTransmitter.sendGraphic(&message1));
             delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&message1));
         } else if (numToSend == 2) {
-            for (innerGraphicsIndex = 0; innerGraphicsIndex < numToSend; innerGraphicsIndex++) 
+            for (innerGraphicsIndex = 0; innerGraphicsIndex < numToSend; innerGraphicsIndex++) {
                 objectsToSend[innerGraphicsIndex]->configGraphicData(&message2.graphicData[innerGraphicsIndex]);
+                layersAreCleared[message2.graphicData[innerGraphicsIndex].layer] = false;
+            }
             PT_CALL(refSerialTransmitter.sendGraphic(&message2));
             delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&message2));
         } else if (numToSend == 5) {
-            for (innerGraphicsIndex = 0; innerGraphicsIndex < numToSend; innerGraphicsIndex++) 
+            for (innerGraphicsIndex = 0; innerGraphicsIndex < numToSend; innerGraphicsIndex++) {
                 objectsToSend[innerGraphicsIndex]->configGraphicData(&message5.graphicData[innerGraphicsIndex]);
+                layersAreCleared[message5.graphicData[innerGraphicsIndex].layer] = false;
+            }
             PT_CALL(refSerialTransmitter.sendGraphic(&message5));
             delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&message5));
         } else if (numToSend == 7) {
-            for (innerGraphicsIndex = 0; innerGraphicsIndex < numToSend; innerGraphicsIndex++) 
+            for (innerGraphicsIndex = 0; innerGraphicsIndex < numToSend; innerGraphicsIndex++) {
                 objectsToSend[innerGraphicsIndex]->configGraphicData(&message7.graphicData[innerGraphicsIndex]);
+                layersAreCleared[message7.graphicData[innerGraphicsIndex].layer] = false;
+            }
             PT_CALL(refSerialTransmitter.sendGraphic(&message7));
             delayTimeout.restart(RefSerialData::Tx::getWaitTimeAfterGraphicSendMs(&message7));
         }

--- a/MCB-project/src/subsystems/ui/UISubsystem.hpp
+++ b/MCB-project/src/subsystems/ui/UISubsystem.hpp
@@ -49,6 +49,9 @@ private:  // Private Variables
     //when get UIDrawCommand, it should set this
     GraphicsContainer* topLevelContainer = nullptr;
 
+    static constexpr int NUM_LAYERS = 10; //layers 0-9
+    bool layersAreCleared[NUM_LAYERS];
+
 public:  // Public Methods
     UISubsystem(tap::Drivers* driver);
     ~UISubsystem() {}  // Intentionally blank


### PR DESCRIPTION
- Adds the ability to recalibrate right before a match starts (during the 15 sec countdown)
- Adds more modes to reticle
- Fixes that pressing x, c, v, or probably some more buttons would make pitch shift
- Also makes it so pressing ctrl closes hopper lid
- c is a shortcut to fastest beyblade
- v is a shortcut to fastest movement